### PR TITLE
Fix display in assemble_common_request_params

### DIFF
--- a/lib/what3words/api.rb
+++ b/lib/what3words/api.rb
@@ -70,7 +70,7 @@ module What3Words
       h = {:key => key}
       h[:lang] = params[:lang] if params[:lang]
       h[:format] = params[:format] if params[:format]
-      h[:display] = params[:format] if params[:format]
+      h[:display] = params[:display] if params[:display]
       h
     end
     private :assemble_common_request_params

--- a/lib/what3words/version.rb
+++ b/lib/what3words/version.rb
@@ -1,3 +1,3 @@
 module What3Words
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end


### PR DESCRIPTION
The display param in assemble_common_request_params was incorrectly using the value of the format param.
