### PR TITLE
Support ruby 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ See http://developer.what3words.com for the original API call documentation
 $ export W3W_API_KEY=<Secret API Key>
 ```
 
-* on you cloned folder
+* on your cloned folder
 1. `$ cd w3w-ruby-wrapper`
 1. `$ bundle update`
 1. `$ rake rubocop spec`

--- a/what3words.gemspec
+++ b/what3words.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rest-client', '~> 1.8'
+  spec.add_dependency('rest-client', '>= 1.8', '< 3.0')
 
   spec.add_development_dependency 'bundler', '>= 1.7.9'
   spec.add_development_dependency 'rake', '~> 11.1'


### PR DESCRIPTION
This PR adds support for Ruby 2.4 and drop support for 1.9.3 (which is already ~2 years past its EOL).